### PR TITLE
DCS-222: Initial docs site setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,44 @@
-# Data Exchange Project
+# DEX (Data Exchange) Product Documentation
 
-This project brings an enterprise wide solution for Data transport and validation to all CDC centers and divisions.
+Welcome to the DEX Products Documentation repository! 
 
-DEX is comprised of several modules or components in multiple repositories:
+## Documentation
 
-* [DEX Upload](https://github.com/CDCgov/data-exchange-upload)
-* [Dex Routing](https://github.com/CDCgov/data-exchange-routing)
-* [DEX HL7 Validation](https://github.com/CDCgov/data-exchange-hl7)
-* [DEX FHIR - add link]()
-* [DEX CSV Validation - add link]()
+The documentation for the DEX Products is located in the `docs/` directory of this repository. The documentation is served as a static website via GitHub Pages, allowing for easy access to it online.
+
+### Accessing the Documentation
+
+You can view the DEX products documentation by visiting the following URL:
+
+[https://cdcgov.github.io/data-exchange](https://cdcgov.github.io/data-exchange)
+
+Alternatively, you can navigate to the `docs/` directory in this repository to view the documentation in markdown format.
+
+## Setup for GitHub Pages
+
+This repository is configured to serve the content of the `docs/` directory via GitHub Pages. The following is configured for GitHub Pages:
+
+1. **Go to the repository settings:**
+   - Navigate to the GitHub repository's main page.
+   - Click on the "Settings" tab.
+
+2. **Scroll to the GitHub Pages section:**
+   - Under the "Code and automation" section in the left sidebar, click on "Pages".
+
+3. **Configure the source branch:**
+   - In the "Source" dropdown menu, select the `main` branch.
+   - In the "Folder" dropdown menu, select `/docs`.
+
+4. **Save your changes:**
+   - Click the "Save" button to apply the changes.
+
+The documentation will now be available via GitHub Pages at the URL mentioned above.
 
 
+## Contributing to Documentation
 
-# CDCgov GitHub Organization Open Source Project Template
+Please contribute to improve the documentation under the `/docs` directory. Feel free to submit pull requests or open issues with any suggestions, additions or changes.
 
-**Template for clearance: This project serves as a template to aid projects in starting up and moving through clearance procedures. To start, create a new repository and implement the required [open practices](open_practices.md), train on and agree to adhere to the organization's [rules of behavior](rules_of_behavior.md), and [send a request through the create repo form](https://forms.office.com/Pages/ResponsePage.aspx?id=aQjnnNtg_USr6NJ2cHf8j44WSiOI6uNOvdWse4I-C2NUNk43NzMwODJTRzA4NFpCUk1RRU83RTFNVi4u) using language from this template as a Guide.**
-
-**General disclaimer** This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise. 
-
-## Access Request, Repo Creation Request
-
-* [CDC GitHub Open Project Request Form](https://forms.office.com/Pages/ResponsePage.aspx?id=aQjnnNtg_USr6NJ2cHf8j44WSiOI6uNOvdWse4I-C2NUNk43NzMwODJTRzA4NFpCUk1RRU83RTFNVi4u) _[Requires a CDC Office365 login, if you do not have a CDC Office365 please ask a friend who does to submit the request on your behalf. If you're looking for access to the CDCEnt private organization, please use the [GitHub Enterprise Cloud Access Request form](https://forms.office.com/Pages/ResponsePage.aspx?id=aQjnnNtg_USr6NJ2cHf8j44WSiOI6uNOvdWse4I-C2NUQjVJVDlKS1c0SlhQSUxLNVBaOEZCNUczVS4u).]_
-
-## Related documents
-
-* [Open Practices](open_practices.md)
-* [Rules of Behavior](rules_of_behavior.md)
-* [Thanks and Acknowledgements](thanks.md)
-* [Disclaimer](DISCLAIMER.md)
-* [Contribution Notice](CONTRIBUTING.md)
-* [Code of Conduct](code-of-conduct.md)
-
-## Overview
-
-Describe the purpose of your project. Add additional sections as necessary to help collaborators and potential collaborators understand and use your project.
   
 ## Public Domain Standard Notice
 This repository constitutes a work of the United States Government and is not

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,66 @@
+# Introduction
+
+## What Is DEX? 
+Public health data systems are critical sources of information that allow our nation to identify and face our most significant health threats. The Centers for Disease Control and Prevention (CDC)’s[ Data Modernization Initiative](https://www.cdc.gov/surveillance/data-modernization/index.html) (DMI) was created to provide better, faster, actionable data sharing for decision-making at all levels of public health.   
+
+The CDC’s Data Exchange (DEX) is essential to the CDC’s DMI efforts. DEX supports public health Data Senders in their effort to share public health data with internal CDC Programs. Data Senders are CDC partners across the country, including:  
+
+- State, tribal, local, and territorial public health authorities  
+- Hospitals and health systems  
+- Laboratories  
+- Trusted Intermediaries   
+
+DEX provides a modern and secure platform for Data Senders to transfer files directly to CDC Programs. DEX supports many standard file formats (HL7v2®, FHIR®, CDA, XML, CSV) and offers the following benefits for users:  
+
+**Data observability –** DEX provides real-time status and tracking information during all stages of their file transfer. 
+
+**Customizable code  –** DEX APIs offer open-source code that your organization can use to create your own solution. 
+
+**Data security –** DEX’s keeps data only in the hands of public health partners who need it. 
+
+**Data-informed decision making –** data submitted to DEX can help predict public health events and inform effective health response. 
+
+## Who Uses DEX? 
+DEX facilitates data modernization, integrity, and security between CDC and our public health partners in the field. We all have essential roles in the data transfer process. 
+
+- **Data Senders** are public health partners who send data to the CDC. 
+- **Data Receivers** are CDC Programs or intermediaries who retrieve or process data sent by Data Senders.  
+- **Data Producers** are public health partners who create public health data. Sometimes, a Data Producer may not be a Data Sender — they may contract with intermediaries to send data. 
+
+
+Whether you need to send data to the CDC or create a custom data transfer solution that meets your needs, several application programming interfaces (APIs) are available to help you. 
+
+# DEX Products
+
+## DEX Processing Status API 
+
+The DEX Processing Status API (PS API) was developed to provide visibility into the status and performance of their file uploads. The PS API provides the ability to both receive reports about the status of uploads, and to develop custom queries to ask detailed questions about the data being uploaded and processed.  
+
+To learn more about the DEX PS API and find out how you can use it to fit your development needs, check out the following resources:  
+
+- [DEX PS API Quick Start Guide](./PS-API/quick-start-guide.md)
+- [DEX PS API Complete Product Guide](./PS-API/product-guide.md)  
+- [DEX PS API Public GitHub Repository](https://github.com/CDCgov/data-exchange-processing-status)  
+
+ 
+## DEX Upload API 
+
+The DEX Upload API provides a modern and secure platform for Data Senders to upload their data directly to CDC Programs and offers the following benefits for users:    
+
+- Resumable and reliable uploads: DEX Upload API is a reliable tool for users to send large files in any format (HL7, FHIR, CDA, XML, CSV). In case of a connection failure, DEX Upload API allows resumable uploads so that users don’t lose their progress during interrupted file transfers.    
+
+- Scalable operations: The API efficiently manages large amounts of data and use cases, making the future state of data sharing more predictable for users.     
+
+To learn more about the DEX Upload API and how it can be customized to fit your needs, check out the following resources:  
+
+- [DEX Upload API Documentation for Existing Customers](./UPLOAD-API/documentation-existing-customers.md)
+- [DEX Upload API Quick Start Guide](./UPLOAD-API/quick-start-guide.md)
+- [DEX Upload API Complete Product Guide](./UPLOAD-API/product-guide)
+- [DEX Upload API Public GitHub Repository](https://github.com/CDCgov/data-exchange-upload) 
+
+
+
+
+
+
+


### PR DESCRIPTION
### Summary:

This PR adds the initial README.md pages for a documentation site that is to utilize the Github pages feature.

The following was done in this PR:

- Edited the main repository README.md. This includes information about the structure of the repository and usage.
- Added a top level README.md under the `docs/` directory. This is the top level page for the static site to be served via Github pages.
- TODO: Files cleanup for the repurpose of this repo.
