### PR TITLE
DCS-224: Setup for GH Pages and Docker Compose Jeykll Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Operating system files
+.DS_Store
+Thumbs.db
+
+# Ruby specific
+.bundle/
+vendor/
+Gemfile.lock
+
+# Jekyll generated site
+_site/
+.jekyll-cache/
+.sass-cache/
+.jekyll-metadata
+
+# Log and backup files
+*.log
+*.tmp
+*.bak
+*.swp
+
+# Bundler config
+.bundle/config
+
+# Coverage reports
+coverage/
+
+# Node specific (if you're using JavaScript tools)
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# IDEs and editors (optional, depending on your setup)
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,44 @@ The documentation will now be available via GitHub Pages at the URL mentioned ab
 
 Please contribute to improve the documentation under the `/docs` directory. Feel free to submit pull requests or open issues with any suggestions, additions or changes.
 
+
+## Running Documentation Site Locally with Docker Compose
+
+To preview the documentation site locally during development, you can use Docker Compose to build and run the site.
+
+### Prerequisites
+
+- Ensure that you have [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on your machine.
+
+### Steps to Run the Site Locally
+
+1. **Clone the repository:**
+    - Clone the repository using your usual method and checkout your development branch.
+
+2. **Build and run the Docker container:**
+
+    - Run the following command to build and start the Jekyll site inside a Docker container:
+        ```
+        docker-compose up
+        ```
+    - **NOTE:** If having issues with errors related to Gem packages missing or certificate related erorrs, you may need to **temporarily disable Zscaler** on first use and start back after packages are installed.
+
+        This will:
+        - Build the Jekyll site.
+        - Serve the site locally at http://localhost:4000.
+
+
+3. **Monitoring Changes:**
+    - Once the site is running, you can make changes to your files. The site will automatically rebuild and refresh when changes are detected, and the updated version will be visible at http://localhost:4000. Refresh pages in your browser to see your changes!
+
+4. **Stopping the Docker Container:**
+    - When you're done, you can stop the Docker container with:
+    ```
+    docker-compose down
+    ```
+
+By following these steps, you'll be able to run your documentation site locally and monitor any changes at http://localhost:4000.
+
   
 ## Public Domain Standard Notice
 This repository constitutes a work of the United States Government and is not

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  web:
+    image: jekyll/jekyll
+    command: jekyll serve --watch --host 0.0.0.0
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./docs:/srv/jekyll
+    working_dir: /srv/jekyll
+    stdin_open: true
+    tty: true

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gem 'github-pages'
+gem 'jekyll-theme-minimal'
+gem 'nokogiri'
+gem 'rack', '~> 2.2.4'
+gem 'rspec'
+gem 'rake'

--- a/docs/PS-API/product-guide.md
+++ b/docs/PS-API/product-guide.md
@@ -1,0 +1,8 @@
+---
+title:  "DEX PS API Complete Product Guide"
+description: "Welcome to the DEX PS-API Complete Product Guide"
+---
+
+# DEX PS API Complete Product Guide
+
+**TODO:**

--- a/docs/PS-API/quick-start-guide.md
+++ b/docs/PS-API/quick-start-guide.md
@@ -1,0 +1,8 @@
+---
+title:  "DEX PS API Quick Start Guide"
+description: "Welcome to the DEX PS API Quick Start Guide"
+---
+
+# DEX PS API Quick Start Guide
+
+**TODO:**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,10 @@
+---
+title:  "DEX (Data Exchange) Product Documentation"
+description: "Welcome to the DEX Products Documentation Site!"
+permalink: "/"
+---
+
+
 # Introduction
 
 ## What Is DEX? 
@@ -38,8 +45,8 @@ The DEX Processing Status API (PS API) was developed to provide visibility into 
 
 To learn more about the DEX PS API and find out how you can use it to fit your development needs, check out the following resources:  
 
-- [DEX PS API Quick Start Guide](./PS-API/quick-start-guide.md)
-- [DEX PS API Complete Product Guide](./PS-API/product-guide.md)  
+- [DEX PS API Quick Start Guide](PS-API/quick-start-guide)
+- [DEX PS API Complete Product Guide](PS-API/product-guide)  
 - [DEX PS API Public GitHub Repository](https://github.com/CDCgov/data-exchange-processing-status)  
 
  
@@ -53,9 +60,9 @@ The DEX Upload API provides a modern and secure platform for Data Senders to upl
 
 To learn more about the DEX Upload API and how it can be customized to fit your needs, check out the following resources:  
 
-- [DEX Upload API Documentation for Existing Customers](./UPLOAD-API/documentation-existing-customers.md)
-- [DEX Upload API Quick Start Guide](./UPLOAD-API/quick-start-guide.md)
-- [DEX Upload API Complete Product Guide](./UPLOAD-API/product-guide)
+- [DEX Upload API Documentation for Existing Customers](UPLOAD-API/documentation-existing-customers)
+- [DEX Upload API Quick Start Guide](UPLOAD-API/quick-start-guide)
+- [DEX Upload API Complete Product Guide](UPLOAD-API/product-guide)
 - [DEX Upload API Public GitHub Repository](https://github.com/CDCgov/data-exchange-upload) 
 
 

--- a/docs/UPLOAD-API/documentation-existing-customers.md
+++ b/docs/UPLOAD-API/documentation-existing-customers.md
@@ -1,0 +1,6 @@
+---
+title:  "DEX UPLOAD API Existing Customer Documentation"
+description: "Welcome to the DEX UPLOAD API Existing Customer Documentation"
+---
+
+# DEX UPLOAD API Existing Customer Documentation

--- a/docs/UPLOAD-API/product-guide.md
+++ b/docs/UPLOAD-API/product-guide.md
@@ -1,0 +1,8 @@
+---
+title:  "DEX UPLOAD API Complete Product Guide"
+description: "Welcome to the DEX UPLOAD API Complete Product Guide"
+---
+
+# DEX UPLOAD API Complete Product Guide
+
+**TODO:**

--- a/docs/UPLOAD-API/quick-start-guide.md
+++ b/docs/UPLOAD-API/quick-start-guide.md
@@ -1,0 +1,8 @@
+---
+title:  "DEX UPLOAD API Quick Start Guide"
+description: "Welcome to the DEX UPLOAD API Quick Start Guide"
+---
+
+# DEX UPLOAD API Quick Start Guide
+
+**TODO:**

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,11 @@
+# _config.yml
+
+# Site settings
+title: DEX (Data Exchange) Product Documentation
+description: Documentation for DEX products
+
+# Jekyll theme settings
+theme: jekyll-theme-minimal # You can choose from GitHub Pages-supported themes
+
+# Set markdown type kramdown or GFM
+markdown: kramdown


### PR DESCRIPTION
### Summary:

This PR adds the following:

- Adds a `.gitignore` for excluding Jekyll and Ruby generated in the local web site build.
- Adds a `docker-compose.yml` for enabling running the Jeykll web service locally for previewing rendered pages locally via `http://localhost:4000`.
- Updates the main `README.md` with instruction on using docker compose for starting the web service container.
- Adds some starting Jeykll Front Page Matter (metadata) for the markdown (.md) pages.